### PR TITLE
Fix folder name in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Folder name in `README.md` from `checkout-custom` to `checkout-ui-custom`.
 
 ## [0.0.2] - 2020-03-23
-
-## [0.0.1] - 2020-02-19
 
 ### Changed
 - Use default settings for template.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ In practice, it means that Checkout UI Settings allows A/B testing in your store
 4. Select the `checkout-ui-settings` option;
 5.  Open the `checkout-ui-settings`  app in whichever code editor you prefer;
 6.  In the  `manifest.json`  file, change the predefined default value  `vendor`  to the name of the account in which you want to install the app;
-7.  In the  `checkout-custom`  folder, create the files in which the scripts will be included, just as you would do in the [admin's interface](https://help.vtex.com/tutorial/configure-template-in-smartcheckout-update--ToTE5XB39t0SwtHgpgwSv?locale=en#configure-code). Notice that a few defaults files already exist in the `checkout-custom` folder, files which you can use to insert the scripts;
+7.  In the  `checkout-ui-custom`  folder, create the files in which the scripts will be included, just as you would do in the [admin's interface](https://help.vtex.com/tutorial/configure-template-in-smartcheckout-update--ToTE5XB39t0SwtHgpgwSv?locale=en#configure-code). Notice that a few defaults files already exist in the `checkout-ui-custom` folder, files which you can use to insert the scripts;
 8.  According to the Checkout customization you are looking for, open the most suitable file and insert the desired scripts;
 9.  Save your changes. Then, [publish](https://vtex.io/docs/recipes/development/publishing-an-app) the app's new version;
 10. Still logged into the desired account, [create a production workspace](https://vtex.io/docs/recipes/development/creating-a-production-workspace) and [install the app](https://vtex.io/docs/recipes/development/installing-an-app);


### PR DESCRIPTION
Correct documentation in `README.md` changing folder name that was previously wrong.